### PR TITLE
Add support for paginated results

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -23,31 +23,53 @@ function postToSlack(deleted, failed) {
   return rp(options);
 }
 
+function getAllImages() {
+  const ecr = new AWS.ECR({ apiVersion: '2015-09-21', region: ecrRegion });
+  const ecrRegion = process.env.ECR_REGION || 'us-east-1';
+  console.log('Robin is using ECR Region: ', ecrRegion);
+
+  const params = {
+    registryId: registry,
+    repositoryName: repoName,
+    maxResults: 100
+  };
+
+  /**
+   * 'Follows' the result pagination in a sort of reduce method in which the results are continuely added to an array
+   */
+  function followPages(allImages, data) {
+    const combinedImages = [...allImages, ...data.imageDetails];
+    
+    if (data.nextToken) {
+      params.nextToken = data.nextToken;
+      return ecr.describeImages(params)
+        .promise()
+        .then(res => followPages(combinedImages, res));
+    }
+
+    return Promise.resolve(combinedImages);
+  }
+
+  return ecr.describeImages(params).promise().then(data => followPages([], data));
+
+}
+
 module.exports.cleanupImages = (event, context, callback) => {
   console.log('Robin is dealing out some of his own justice...');
   
   const isDryRun = process.env.DRY_RUN === 'true';
   console.log('Robin is running in dry run mode: ', isDryRun);
 
-  const ecrRegion = process.env.ECR_REGION || 'us-east-1';
-  console.log('Robin is using ECR Region: ', ecrRegion);
 
-  const ecr = new AWS.ECR({ apiVersion: '2015-09-21', region: ecrRegion });
 
   const cutOffDate = moment().add(-30, 'd');
   console.log('Using cut off date: ', cutOffDate);
 
   const promises = repoNames.map(repoName => {
-    const params = {
-      registryId: registry,
-      repositoryName: repoName,
-      maxResults: 100
-    };
 
-    return ecr.describeImages(params)
-      .promise()
+    return getAllImages()
       .then(images => { // eslint-disable-line arrow-body-style
-        return filter(images.imageDetails, image => (
+        return filter(images, image => (
           // filters out images that are 30 days old and don't contain the master tag
           moment(image.imagePushedAt).isBefore(cutOffDate)
           && !image.imageTags.find(tag => tag.indexOf('master') > -1)

--- a/handler.js
+++ b/handler.js
@@ -23,8 +23,9 @@ function postToSlack(deleted, failed) {
   return rp(options);
 }
 
-function getAllImages() {
-  const ecr = new AWS.ECR({ apiVersion: '2015-09-21', region: ecrRegion });
+const ecr = new AWS.ECR({ apiVersion: '2015-09-21', region: ecrRegion });
+
+function getAllImages(repoName) {
   const ecrRegion = process.env.ECR_REGION || 'us-east-1';
   console.log('Robin is using ECR Region: ', ecrRegion);
 
@@ -60,14 +61,12 @@ module.exports.cleanupImages = (event, context, callback) => {
   const isDryRun = process.env.DRY_RUN === 'true';
   console.log('Robin is running in dry run mode: ', isDryRun);
 
-
-
   const cutOffDate = moment().add(-30, 'd');
   console.log('Using cut off date: ', cutOffDate);
 
   const promises = repoNames.map(repoName => {
 
-    return getAllImages()
+    return getAllImages(repoName)
       .then(images => { // eslint-disable-line arrow-body-style
         return filter(images, image => (
           // filters out images that are 30 days old and don't contain the master tag

--- a/handler.js
+++ b/handler.js
@@ -23,10 +23,10 @@ function postToSlack(deleted, failed) {
   return rp(options);
 }
 
+const ecrRegion = process.env.ECR_REGION || 'us-east-1';
 const ecr = new AWS.ECR({ apiVersion: '2015-09-21', region: ecrRegion });
 
 function getAllImages(repoName) {
-  const ecrRegion = process.env.ECR_REGION || 'us-east-1';
   console.log('Robin is using ECR Region: ', ecrRegion);
 
   const params = {

--- a/handler.js
+++ b/handler.js
@@ -43,7 +43,6 @@ function getAllImages(repoName) {
     
     if (data.nextToken) {
       params.nextToken = data.nextToken;
-      console.log(params);
       return ecr.describeImages(params)
         .promise()
         .then(res => followPages(combinedImages, res));

--- a/handler.js
+++ b/handler.js
@@ -43,6 +43,7 @@ function getAllImages(repoName) {
     
     if (data.nextToken) {
       params.nextToken = data.nextToken;
+      console.log(params);
       return ecr.describeImages(params)
         .promise()
         .then(res => followPages(combinedImages, res));

--- a/handler.js
+++ b/handler.js
@@ -64,9 +64,8 @@ module.exports.cleanupImages = (event, context, callback) => {
   const cutOffDate = moment().add(-30, 'd');
   console.log('Using cut off date: ', cutOffDate);
 
-  const promises = repoNames.map(repoName => {
-
-    return getAllImages(repoName)
+  const promises = repoNames.map(repoName => (
+    getAllImages(repoName)
       .then(images => { // eslint-disable-line arrow-body-style
         return filter(images, image => (
           // filters out images that are 30 days old and don't contain the master tag
@@ -94,8 +93,8 @@ module.exports.cleanupImages = (event, context, callback) => {
         console.log('Deleted images: ', deleteData.imageIds);
         console.log('Delete failures: ', deleteData.failures);
         return postToSlack(deleteData.imageIds, deleteData.failures);
-      });
-  });
+      })
+  ));
 
   return Promise.all(promises)
     .then(() => {

--- a/handler.test.js
+++ b/handler.test.js
@@ -98,4 +98,63 @@ describe('cleanupImages', () => {
       done();
     });
   });
+
+  it('Should handle pagination using the nextToken', done => {
+
+    const stub = sandbox.stub();
+    stub.onCall(0).returns({
+      promise: () => Promise.resolve(
+        {
+          nextToken: 'next-please',
+          imageDetails: [{
+            registryId: '384553929753',
+            repositoryName: 'test-repo-1',
+            imageDigest: '4',
+            imageTags: ['1.0.0-other', 'dont-ignore-this'],
+            imageSizeInBytes: '1024',
+            imagePushedAt: moment().add(-31, 'days')
+          }]
+        })
+    });
+
+    stub.onCall(1).returns({
+      promise: () => Promise.resolve(
+        {
+          nextToken: null,
+          imageDetails: [{
+            registryId: '384553929754',
+            repositoryName: 'test-repo-2',
+            imageDigest: '4',
+            imageTags: ['1.0.0-other', 'dont-ignore-this'],
+            imageSizeInBytes: '1024',
+            imagePushedAt: moment().add(-31, 'days')
+          }]
+        })
+    });
+
+    const cleanupImagesProxy = proxyquire('./handler.js', {
+      'aws-sdk': {
+        ECR: function () { // eslint-disable-line
+          this.batchDeleteImage = deleteStub;
+          this.describeImages = stub;
+        }
+      },
+      'request-promise': rpStub
+    });
+
+    process.env.DRY_RUN = false;
+
+    cleanupImagesProxy.cleanupImages(null, null, () => {
+      const secondCall = stub.getCall(1);
+      
+      assert(secondCall.calledWithMatch({
+        registryId: '441581275790',
+        repositoryName: 'test-repo',
+        maxResults: 100,
+        nextToken: 'next-please'
+      }), 'describeImages was not called with the next token for the 2nd time');
+      assert(stub.callCount === 2, 'describeImages was not called 2 times');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Pretty much implements the same logic found in hammertime to follow paginated results returned from the AWS `describeImages` api. Solves #2 