### PR TITLE
Limit results to 100

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -23,7 +23,7 @@ function getAllImages(ecr, registryId, repoName) {
   const params = {
     registryId,
     repositoryName: repoName,
-    maxResults: 500
+    maxResults: 100
   };
 
   /**

--- a/handler.test.js
+++ b/handler.test.js
@@ -147,7 +147,7 @@ describe('cleanupImages', () => {
       assert(secondCall.calledWithMatch({
         registryId: '1234567890',
         repositoryName: 'test-repo',
-        maxResults: 500,
+        maxResults: 100,
         nextToken: 'next-please'
       }), 'describeImages was not called with the next token for the 2nd time');
       assert(stub.callCount === 2, 'describeImages was not called 2 times');


### PR DESCRIPTION
While its possible to query for up to 1000 images, its only possible to batch delete 100 at a time.